### PR TITLE
Fix installation versioning issues in both conda yml and setup.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: civet_cog_uk
+name: civet
 channels:
   - conda-forge
   - bioconda

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: civet
+name: civet_cog_uk
 channels:
   - conda-forge
   - bioconda
@@ -16,6 +16,8 @@ dependencies:
   - openjdk
   - cov-ert::jclusterfunk
   - benjamincjackson::gofasta
+  - importlib-metadata=3.10.1
+  - pyproj=3.0.0
   - pip:
     - pandas==1.1.0
     - pytools==2020.1
@@ -24,7 +26,9 @@ dependencies:
     - grip>=4.5.2
     - descartes>=1.1.0
     - adjustText>=0.7.3
+    - click==7.1.2
     - git+https://github.com/cov-ert/datafunk.git
     - git+https://github.com/cov-ert/reportfunk.git
     - git+https://github.com/cov-ert/clusterfunk.git
+    - Cython==0.29.24
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(name='civet',
             "adjustText>=0.7.3",
             "grip>=4.5.2",
             "tabulate>=0.8.7",
-            "snipit>=1.0.3"
+            "snipit>=1.0.3",
+	    "traitlets>=5.0"
         ],
       cmdclass={
         'npm_install': NPMInstall


### PR DESCRIPTION
I encountered a number of installation issues with incompatible versions of PROJ with pyproj as well as traits with nbconvert during the standard installation procedure. I have modified the environment.yml and setup.py accordingly to the required module versions. Installation now completes as expected through conda. 