### PR TITLE
Generalise to other viruses - added customisable reference sequence and outgroup to config file

### DIFF
--- a/civet/analysis_functions/catchment_parsing.py
+++ b/civet/analysis_functions/catchment_parsing.py
@@ -230,7 +230,7 @@ def write_catchment_fasta(catchment_metadata,fasta,catchment_dir,config):
 
         with open(os.path.join(catchment_dir,f"{catchment}.fasta"),"w") as fw:
             records = seq_dict[catchment]
-            for record in SeqIO.parse(config["outgroup_fasta"],"fasta"):
+            for record in SeqIO.parse(config[KEY_OUTGROUP_FASTA],"fasta"):
                 records.append(record)
             SeqIO.write(records,fw,"fasta")
 

--- a/civet/command.py
+++ b/civet/command.py
@@ -23,6 +23,11 @@ from civet.utils.config import *
 import os
 import sys
 import argparse
+import warnings
+
+# Silence repeated pkg_resources deprecation warnings coming from dependencies (stopit/pkg_resources)
+warnings.filterwarnings("ignore", message=".*pkg_resources is deprecated.*", category=UserWarning)
+
 import snakemake
 
 cwd = os.getcwd()
@@ -163,6 +168,8 @@ Default: `the_usual`""")
     misc_group.add_argument("--date-format", action="store",dest="date_format",help="Option to parse differently formatted date strings. Default: YYYY-MM-DD")
     misc_group.add_argument("--civet-mode", action="store", dest='civet_mode', help="If CLIMB then import UK specific modules. Default=`GLOBAL`")
     misc_group.add_argument("-r","--reference-sequence",action="store",dest="reference_sequence",help="Custom reference genome to map and pad against. Must match the reference the background sequence alignment was generated from.")
+    misc_group.add_argument("--outgroup-sequence", action="store", dest="outgroup_fasta",
+                            help="Custom outgroup fasta to use instead of packaged outgroup.fasta")
     misc_group.add_argument("--art",action="store_true",help="Print art")
     misc_group.add_argument("--acknowledgements",action="store_true",help="Print thanks")
     misc_group.add_argument('-t', '--threads', action='store',dest="threads",type=int,help="Number of threads")
@@ -264,6 +271,9 @@ Default: `the_usual`""")
     input_arg_parsing.input_fasta_parsing(args.input_sequences,args.max_ambiguity,args.min_length,config)
 
     input_arg_parsing.from_metadata_parsing(config)
+
+    # Allow user to override packaged outgroup fasta
+    misc.add_file_to_config(KEY_OUTGROUP_FASTA, args.outgroup_fasta, config)
 
     snakefile = data_install_checks.get_snakefile(thisdir)
 

--- a/civet/input_parsing/initialising.py
+++ b/civet/input_parsing/initialising.py
@@ -32,6 +32,10 @@ def get_defaults():
                     KEY_TRIM_START:265,   # where to pad to using datafunk
                     KEY_TRIM_END:29674,
 
+                    # reference / outgroup
+                    KEY_REFERENCE_SEQUENCE: False,
+                    KEY_OUTGROUP_FASTA: False,
+
                     # background variables
                     
                     CIVET_DATADIR: os.getenv('CIVET_DATADIR'),
@@ -299,7 +303,7 @@ def load_yaml(f):
     return input_config
 
 def return_path_keys():
-    return [KEY_INPUT_METADATA,KEY_INPUT_SEQUENCES,KEY_BACKGROUND_METADATA,KEY_BACKGROUND_SEQUENCES,KEY_BACKGROUND_TREE,KEY_BACKGROUND_SNPS,CIVET_DATADIR,KEY_OUTDIR,KEY_TEMPDIR]
+    return [KEY_INPUT_METADATA,KEY_INPUT_SEQUENCES,KEY_BACKGROUND_METADATA,KEY_BACKGROUND_SEQUENCES,KEY_BACKGROUND_TREE,KEY_BACKGROUND_SNPS,CIVET_DATADIR,KEY_OUTDIR,KEY_TEMPDIR,KEY_REFERENCE_SEQUENCE,KEY_OUTGROUP_FASTA]
 
 def setup_absolute_paths(path_to_file,value):
     return os.path.join(path_to_file,value)

--- a/civet/utils/config.py
+++ b/civet/utils/config.py
@@ -154,6 +154,7 @@ KEY_DATE="date"
 KEY_AUTHORS="authors"
 
 KEY_REFERENCE_SEQUENCE="reference_sequence"
+KEY_OUTGROUP_FASTA="outgroup_fasta"
 
 RESOURCE_KEY_FILENAME="filename"
 RESOURCE_KEY_DIRECTORY="directory"
@@ -169,10 +170,10 @@ dependency_list = ["gofasta","minimap2","snakemake","iqtree","jclusterfunk","sco
 module_list = ["mako","Bio"]
 
 resources = [
-        {RESOURCE_KEY:"reference_sequence",
+        {RESOURCE_KEY:KEY_REFERENCE_SEQUENCE,
         RESOURCE_KEY_DIRECTORY:"data",
         RESOURCE_KEY_FILENAME:"reference.fasta"},
-        {RESOURCE_KEY:"outgroup_fasta",
+        {RESOURCE_KEY:KEY_OUTGROUP_FASTA,
         RESOURCE_KEY_DIRECTORY:"data",
         RESOURCE_KEY_FILENAME:"outgroup.fasta"},
         {RESOURCE_KEY:"report_template",

--- a/civet/utils/data_install_checks.py
+++ b/civet/utils/data_install_checks.py
@@ -8,6 +8,10 @@ from civet.utils.config import *
 
 def package_data_check(filename,directory,key,config):
     try:
+        # If the user has supplied a value for this config key (via CLI or config file),
+        # do not overwrite it with the packaged resource path.
+        if key in config and config[key]:
+            return
         package_datafile = os.path.join(directory,filename)
         data = pkg_resources.resource_filename('civet', package_datafile)
         config[key] = data


### PR DESCRIPTION
Hi Aine!

Off the back of our conversation (semi-)recently, here are the changes I made to Civet to generalise outside of the SARS-CoV2 context. Seems like it was just the ingestion of outgroup/reference sequences that needed changing in the actual code. From memory, the minimum sequence length and trim parameters (unsurprisingly) need to be specified explicitly in the config for non-SARS-CoV2 use cases.

I'll attach a zip archive of all the data (test and background data, config file, outgroup, reference) needed to run on the example I used to test this, piscine myocarditis virus (PMCV) so you can satisfy yourself it is working as you would hope. 

[example.zip](https://github.com/user-attachments/files/28306057/example.zip)

Let me know if you need anything else.

P.s. Just in case it's useful, here's the SOP I wrote for grant partners: 

[CIVET_ClusterAnalysisSOP.docx](https://github.com/user-attachments/files/28306089/CIVET_ClusterAnalysisSOP.docx)